### PR TITLE
fix: `:canonical-link` is lower-case

### DIFF
--- a/src/ukko/core.clj
+++ b/src/ukko/core.clj
@@ -253,7 +253,8 @@
 
 (defn add-canonical-link [{:keys [id target-extension] :as artifact}]
   ;; (println (color/magenta "Add canonical-link") (str "/" id target-extension))
-  (assoc artifact :canonical-link (str "/" id target-extension)))
+  (assoc artifact :canonical-link (-> (str "/" id target-extension)
+                                      str/lower-case)))
 
 (defn add-word-count [{:keys [template] :as artifact}]
   ;; TODO: dont use template for this but the result after


### PR DESCRIPTION
Dealing with stupid people using non-lowercase letters in their filenames.

![image](https://user-images.githubusercontent.com/505721/183872827-d529b368-03c3-4ae0-8b66-71ddfe830823.png)


vs 

![image](https://user-images.githubusercontent.com/505721/183872928-af585260-6066-4058-b561-c8a00df87f9c.png)
